### PR TITLE
Add LOG_TYPE option for AWS-compatible logging

### DIFF
--- a/src/context/request-context.ts
+++ b/src/context/request-context.ts
@@ -8,38 +8,52 @@
         private readonly _traceContext: TraceContext | null;
         private readonly _startTime: [number, number];
         private readonly _metadata: Map<string, any>;
+        private readonly _logType: 'gcp' | 'aws';
 
         constructor() {
             this._requestId = '';
             this._traceContext = null;
             this._startTime = process.hrtime();
             this._metadata = new Map();
+            this._logType = 'gcp';
         }
 
-        static create(req: Request): RequestContext {
+        static create(req: Request, logType: 'gcp' | 'aws' = 'gcp'): RequestContext {
             const context = new RequestContext();
             Object.defineProperties(context, {
                 _requestId: {
-                    value: req.headers['x-request-id'] || 
+                    value: req.headers['x-request-id'] ||
                         randomBytes(16).toString('hex').slice(0, 8),
                     writable: false
                 },
                 _traceContext: {
-                    value: this.createTraceContext(req),
+                    value: this.createTraceContext(req, logType),
+                    writable: false
+                },
+                _logType: {
+                    value: logType,
                     writable: false
                 }
             });
             return context;
         }
 
-        private static createTraceContext(req: Request): TraceContext {
-            let traceContext: TraceContext;
-            
-            if (req.headers['x-cloud-trace-context']) {
+        private static createTraceContext(req: Request, logType: 'gcp' | 'aws'): TraceContext {
+            let traceContext: TraceContext | null = null;
+
+            if (logType === 'aws' && req.headers['x-amzn-trace-id']) {
+                traceContext = TraceContext.parseXAmznTraceId(
+                    req.headers['x-amzn-trace-id'] as string
+                );
+            }
+
+            if (!traceContext && req.headers['x-cloud-trace-context']) {
                 traceContext = TraceContext.parseCloudTrace(
                     req.headers['x-cloud-trace-context'] as string
                 );
-            } else {
+            }
+
+            if (!traceContext) {
                 traceContext = TraceContext.parseTraceParent(
                     req.headers.traceparent as string
                 );
@@ -65,6 +79,10 @@
             return this._traceContext;
         }
 
+        get logType(): 'gcp' | 'aws' {
+            return this._logType;
+        }
+
         getElapsedMs(): string {
             const diff = process.hrtime(this._startTime);
             return (diff[0] * 1e3 + diff[1] * 1e-6).toFixed(2);
@@ -73,13 +91,17 @@
         addTraceHeaders(headers: Record<string, string> = {}): Record<string, string> {
             if (this._traceContext) {
                 headers.traceparent = this._traceContext.toTraceParent();
-                
+
                 const tracestate = this._traceContext.toTraceState();
                 if (tracestate) {
                     headers.tracestate = tracestate;
                 }
 
-                headers['x-cloud-trace-context'] = this._traceContext.toCloudTrace();
+                if (this._logType === 'aws') {
+                    headers['x-amzn-trace-id'] = this._traceContext.toXAmznTraceId();
+                } else {
+                    headers['x-cloud-trace-context'] = this._traceContext.toCloudTrace();
+                }
             }
 
             headers['x-request-id'] = this._requestId;
@@ -95,8 +117,12 @@
                     writable: false
                 },
                 _traceContext: {
-                    value: this._traceContext?.createChildSpan() || 
+                    value: this._traceContext?.createChildSpan() ||
                         TraceContext.generateNew(),
+                    writable: false
+                },
+                _logType: {
+                    value: this._logType,
                     writable: false
                 }
             });

--- a/src/context/trace-context.ts
+++ b/src/context/trace-context.ts
@@ -8,9 +8,20 @@ export class TraceContext {
     private traceFlags: string = '01';
     private traceState: Map<string, string> = new Map();
 
-    static generateNew(): TraceContext {
+    static generateNew(awsFormat: boolean = false): TraceContext {
         const context = new TraceContext();
-        context.traceId = randomBytes(16).toString('hex');
+        
+        if (awsFormat) {
+            // Generate AWS X-Ray format: 1-{timestamp}-{traceId}
+            const epochSeconds = Math.floor(Date.now() / 1000);
+            const hexTimestamp = epochSeconds.toString(16).padStart(8, '0').toLowerCase();
+            const traceIdHex = randomBytes(12).toString('hex').toLowerCase(); // 24 hex chars
+            context.traceId = `1-${hexTimestamp}-${traceIdHex}`;
+        } else {
+            // Generate standard W3C format (32 hex chars)
+            context.traceId = randomBytes(16).toString('hex');
+        }
+        
         context.spanId = randomBytes(8).toString('hex');
         return context;
     }
@@ -77,42 +88,61 @@ export class TraceContext {
         const context = new TraceContext();
 
         if (!header) {
-            return TraceContext.generateNew();
+            return TraceContext.generateNew(true);
         }
 
         try {
-            const parts = header.split(';').reduce((acc, part) => {
-                const [key, value] = part.split('=');
-                if (key && value) {
-                    acc[key.trim().toLowerCase()] = value.trim();
+            // Format: Root=1-{timestamp}-{traceId};Parent={spanId};Sampled={0|1}
+            // Example: Root=1-69313ce7-190b8f6099d578eaf1f561bc;Parent=745315306bfc9ca3;Sampled=1
+            
+            // Remove quotes if present
+            header = header.replace(/^["']|["']$/g, '');
+            
+            const parts = header.split(';');
+            let rootPart = '';
+            let parentPart = '';
+            let sampled = '1';
+
+            for (const part of parts) {
+                const trimmed = part.trim();
+                if (trimmed.startsWith('Root=')) {
+                    rootPart = trimmed.substring(5); // Remove 'Root='
+                } else if (trimmed.startsWith('Parent=')) {
+                    parentPart = trimmed.substring(7); // Remove 'Parent='
+                } else if (trimmed.startsWith('Sampled=')) {
+                    sampled = trimmed.substring(8); // Remove 'Sampled='
                 }
-                return acc;
-            }, {} as Record<string, string>);
-
-            const root = parts['root'];
-            if (!root) {
-                return TraceContext.generateNew();
             }
 
-            const rootParts = root.split('-');
-            if (rootParts.length !== 3) {
-                return TraceContext.generateNew();
+            if (!rootPart) {
+                return TraceContext.generateNew(true);
             }
 
-            const [, timestamp, identifier] = rootParts;
-            const traceId = `${timestamp}${identifier}`;
-
-            if (!/^[0-9a-f]{32}$/i.test(traceId)) {
-                return TraceContext.generateNew();
+            // Extract trace ID from Root format: 1-{timestamp}-{traceId}
+            // Store the full AWS format as traceId
+            const rootParts = rootPart.split('-');
+            if (rootParts.length >= 3) {
+                // Full AWS trace ID format: 1-{timestamp}-{traceId}
+                // Store the full AWS format as traceId
+                context.traceId = rootPart; // Keep as 1-{timestamp}-{traceId} format
+            } else {
+                // Fallback: use the rootPart as-is
+                context.traceId = rootPart;
             }
 
-            context.traceId = traceId.toLowerCase();
-            context.spanId = randomBytes(8).toString('hex');
-            context.traceFlags = parts['sampled'] === '0' ? '00' : '01';
+            // Extract span ID from Parent
+            if (parentPart) {
+                // AWS span ID is 16 hex chars, convert to our format (8 bytes = 16 hex)
+                context.spanId = parentPart.replace(/[^0-9a-f]/gi, '').slice(0, 16).padStart(16, '0').toLowerCase();
+            } else {
+                context.spanId = randomBytes(8).toString('hex');
+            }
+            
+            context.traceFlags = (sampled === '0' ? '00' : '01');
 
             return context;
         } catch {
-            return TraceContext.generateNew();
+            return TraceContext.generateNew(true);
         }
     }
 
@@ -148,9 +178,23 @@ export class TraceContext {
     }
 
     toXAmznTraceId(): string {
-        const rootTraceId = `1-${this.traceId.slice(0, 8)}-${this.traceId.slice(8)}`;
+        // If traceId is already in AWS format (1-{timestamp}-{traceId}), use it directly
+        if (typeof this.traceId === 'string' && /^1-[0-9a-f]{8}-[0-9a-f]{24}$/i.test(this.traceId)) {
+            const spanIdHex = this.spanId.replace(/[^0-9a-f]/gi, '').slice(0, 16).padStart(16, '0').toLowerCase();
+            const sampled = this.traceFlags === '01' ? '1' : '0';
+            return `Root=${this.traceId};Parent=${spanIdHex};Sampled=${sampled}`;
+        }
+
+        // Convert standard trace ID to AWS format
+        const epochSeconds = Math.floor(Date.now() / 1000);
+        const hexTimestamp = epochSeconds.toString(16).padStart(8, '0').toLowerCase();
+        const traceIdHex = this.traceId.replace(/[^0-9a-f]/gi, '').slice(0, 24).padStart(24, '0').toLowerCase();
+        const awsTraceId = `1-${hexTimestamp}-${traceIdHex}`;
+
+        const spanIdHex = this.spanId.replace(/[^0-9a-f]/gi, '').slice(0, 16).padStart(16, '0').toLowerCase();
         const sampled = this.traceFlags === '01' ? '1' : '0';
-        return `Root=${rootTraceId};Parent=${this.spanId};Sampled=${sampled}`;
+
+        return `Root=${awsTraceId};Parent=${spanIdHex};Sampled=${sampled}`;
     }
 
     createChildSpan(): TraceContext {

--- a/src/interfaces/logger-config.interface.ts
+++ b/src/interfaces/logger-config.interface.ts
@@ -5,6 +5,7 @@ import type { Level as LogLevel } from 'pino';
 export interface LoggerConfig {
     LOG_LEVEL?: LogLevel;
     LOG_FORMAT?: 'json' | 'pretty';
+    LOG_TYPE?: 'gcp' | 'aws';
     PROJECT_ID: string;
     SERVICE_NAME: string;
     LOGGER_NAME?: string;

--- a/src/logger/base-logger.service.ts
+++ b/src/logger/base-logger.service.ts
@@ -39,10 +39,14 @@ export class BaseLoggerService {
       }
     };
 
+    // Check LOG_TYPE - for AWS, don't use Pino's timestamp (we add our own 'timestamp' field)
+    const logType = this.config.LOG_TYPE || 'gcp';
+    const timestamp = logType === 'aws' ? false : pino.stdTimeFunctions.isoTime;
+
     return pino({
       level: this.config.LOG_LEVEL || 'info',
       messageKey: 'message',
-      timestamp: pino.stdTimeFunctions.isoTime,
+      timestamp,
       formatters,
       serializers,
       transport,

--- a/src/utils/aws-formatter.ts
+++ b/src/utils/aws-formatter.ts
@@ -1,0 +1,225 @@
+// src/utils/aws-formatter.ts
+import { SEVERITY_LEVEL } from '../config/constants';
+import { randomBytes } from 'crypto';
+
+const getConfigValue = (key: string, defaultValue: string): string => {
+    return process.env[key] || defaultValue;
+};
+
+const convertToAwsXRayTraceId = (traceId: any, timestamp: string | null = null): string | null => {
+    if (!traceId) return null;
+    
+    if (typeof traceId === 'string' && /^1-[0-9a-f]{8}-[0-9a-f]{24}$/i.test(traceId)) {
+        return traceId;
+    }
+    
+    if (typeof traceId === 'string' && traceId.startsWith('Root=')) {
+        return traceId.replace('Root=', '');
+    }
+    
+    const epochSeconds = timestamp 
+        ? Math.floor(new Date(timestamp).getTime() / 1000)
+        : Math.floor(Date.now() / 1000);
+    
+    const hexTimestamp = epochSeconds.toString(16).padStart(8, '0').toLowerCase();
+    
+    const traceIdStr = typeof traceId === 'string' ? traceId : traceId.toString(16);
+    const traceIdHex = traceIdStr.replace(/[^0-9a-f]/gi, '').slice(0, 24).padStart(24, '0').toLowerCase();
+    
+    return `1-${hexTimestamp}-${traceIdHex}`;
+};
+
+const generateXAmznTraceId = (traceId: string | null, spanId: string | null, sampled: boolean = true): string | null => {
+    if (!traceId) return null;
+    
+    const awsTraceId = (typeof traceId === 'string' && /^1-[0-9a-f]{8}-[0-9a-f]{24}$/i.test(traceId))
+        ? traceId
+        : convertToAwsXRayTraceId(traceId);
+    
+    if (!awsTraceId) return null;
+    
+    const spanIdHex = spanId 
+        ? spanId.replace(/[^0-9a-f]/gi, '').slice(0, 16).padStart(16, '0').toLowerCase()
+        : null;
+    
+    const parts = [`Root=${awsTraceId}`];
+    if (spanIdHex) {
+        parts.push(`Parent=${spanIdHex}`);
+    }
+    parts.push(`Sampled=${sampled ? '1' : '0'}`);
+    
+    return parts.join(';');
+};
+
+export const formatAwsLog = (object: Record<string, any>): Record<string, any> => {
+    if (!object || typeof object !== 'object') {
+        return object;
+    }
+
+    const logType = object.LOG_TYPE || object.logType || getConfigValue('LOG_TYPE', 'gcp');
+    
+    if (logType !== 'aws') {
+        return object;
+    }
+
+    const {
+        pid, hostname, level, levelNumber, time, timestamp,
+        msg, severity, requestId, service,
+        traceId, spanId,
+        method, url, path, params, remoteAddress, headers, request_payload,
+        httpRequest, response,
+        type, target_service, instance, region, account_id,
+        graphql,
+        ...rest
+    } = object;
+    
+    const levelToSeverity: Record<number, string> = {
+        10: 'DEBUG',  
+        20: 'DEBUG',  
+        30: 'INFO',   
+        40: 'WARNING', 
+        50: 'ERROR',   
+        60: 'CRITICAL' 
+    };
+
+    const result: Record<string, any> = {};
+    
+    if (severity) {
+        result.severity = severity;
+    } else if (level !== undefined) {
+        result.severity = levelToSeverity[level] || SEVERITY_LEVEL['info'] || 'INFO';
+    } else {
+        result.severity = 'INFO';
+    }
+    
+    if (level !== undefined) {
+        result.level = level;
+    }
+    
+    result.timestamp = timestamp || time || new Date().toISOString();
+    
+    if (type) {
+        result.type = type;
+    }
+    
+    if (service) {
+        result.service = service;
+    }
+    
+    if (pid !== undefined) {
+        result.pid = pid;
+    }
+    
+    if (hostname) {
+        result.hostname = hostname;
+    }
+    
+    const finalRequestId = requestId || rest?.requestId || object.requestId;
+    result.requestId = (finalRequestId && finalRequestId !== '' && finalRequestId !== null && finalRequestId !== undefined) 
+        ? finalRequestId 
+        : randomBytes(16).toString('hex').slice(0, 8);
+    
+    if (rest && rest.requestId) {
+        delete rest.requestId;
+    }
+    
+    if (traceId) {
+        const awsTraceId = convertToAwsXRayTraceId(traceId, result.timestamp);
+        result.traceId = awsTraceId; // Replace traceId with AWS format
+        result['x-amzn-trace-id'] = generateXAmznTraceId(awsTraceId, spanId);
+        result.sampled = true;
+    }
+    
+    if (spanId) {
+        result.spanId = spanId.replace(/[^0-9a-f]/gi, '').slice(0, 16).padStart(16, '0').toLowerCase();
+    }
+    
+    const requestMethod = method || httpRequest?.requestMethod;
+    const requestUrl = url || path || httpRequest?.requestUrl;
+    const requestPath = path || (httpRequest?.requestUrl ? (() => {
+        try {
+            const urlObj = new URL(httpRequest.requestUrl);
+            return urlObj.pathname;
+        } catch {
+            return httpRequest.requestUrl;
+        }
+    })() : null);
+    const requestParams = params;
+    const requestRemoteAddress = remoteAddress || httpRequest?.remoteIp;
+    const requestHeaders = headers || httpRequest?.headers;
+    const requestPayload = request_payload || httpRequest?.requestBody;
+    
+    if (requestMethod) result.method = requestMethod;
+    if (requestUrl) result.url = requestUrl;
+    if (requestPath) result.path = requestPath;
+    if (requestParams !== undefined) result.params = requestParams;
+    if (requestRemoteAddress) result.remoteAddress = requestRemoteAddress;
+    if (requestHeaders) result.headers = requestHeaders;
+    if (requestPayload) result.request_payload = requestPayload;
+    if (target_service) result.target_service = target_service;
+    
+    if (response) {
+        result.response = response;
+    }
+
+    if (graphql) {
+        result.graphql = graphql;
+    } else if (httpRequest?.graphql) {
+        result.graphql = httpRequest.graphql;
+    }
+    
+    const serviceName = service;
+    result.aws = {
+        cloudwatch: {
+            log_group: `/aws/service/${serviceName}`,
+            log_stream: instance || 'instance-1',
+            region: region || process.env.AWS_REGION,
+            account_id: account_id || process.env.AWS_ACCOUNT_ID
+        }
+    };
+    
+    const allowedExtraFields = ['response', 'graphql'];
+    
+    Object.keys(rest).forEach(key => {
+        if (!key.startsWith('logging.googleapis.com/') &&
+            key !== 'resource' &&
+            key !== 'levelNumber' &&
+            key !== 'time' &&
+            key !== 'msg' &&
+            key !== 'httpRequest' &&
+            key !== 'LOG_TYPE' &&
+            key !== 'logType' &&
+            !result.hasOwnProperty(key) &&
+            allowedExtraFields.includes(key)) {
+            result[key] = rest[key];
+        }
+    });
+    
+    const fieldsToRemove = [
+        'time',
+        'logging.googleapis.com/logName',
+        'logging.googleapis.com/trace',
+        'logging.googleapis.com/spanId',
+        'logging.googleapis.com/labels',
+        'logging.googleapis.com/sourceLocation',
+        'logging.googleapis.com/operation',
+        'logging.googleapis.com/httpRequest',
+        'resource',
+        'levelNumber',
+        'msg',
+        'httpRequest',
+        'LOG_TYPE',
+        'logType'
+    ];
+    
+    Object.keys(result).forEach(key => {
+        if (key.startsWith('logging.googleapis.com/')) {
+            delete result[key];
+        }
+    });
+    
+    delete result.time;
+    
+    return result;
+};
+

--- a/src/utils/aws-formatter.ts
+++ b/src/utils/aws-formatter.ts
@@ -195,23 +195,6 @@ export const formatAwsLog = (object: Record<string, any>): Record<string, any> =
         }
     });
     
-    const fieldsToRemove = [
-        'time',
-        'logging.googleapis.com/logName',
-        'logging.googleapis.com/trace',
-        'logging.googleapis.com/spanId',
-        'logging.googleapis.com/labels',
-        'logging.googleapis.com/sourceLocation',
-        'logging.googleapis.com/operation',
-        'logging.googleapis.com/httpRequest',
-        'resource',
-        'levelNumber',
-        'msg',
-        'httpRequest',
-        'LOG_TYPE',
-        'logType'
-    ];
-    
     Object.keys(result).forEach(key => {
         if (key.startsWith('logging.googleapis.com/')) {
             delete result[key];

--- a/src/utils/console-override.ts
+++ b/src/utils/console-override.ts
@@ -17,6 +17,7 @@ interface ConsoleOverrideConfig {
     preserveOriginal?: boolean;
     projectId?: string;
     service?: string;
+    logType?: 'gcp' | 'aws';
 }
 
 const originalConsole: OriginalConsole = {
@@ -106,6 +107,7 @@ const formatArgs = (
     }).join(' ');
 
     const context = asyncLocalStorage.getStore();
+    const logType = (config.logType || process.env.LOG_TYPE || 'gcp').toLowerCase();
 
     const logData = {
         message,
@@ -116,7 +118,8 @@ const formatArgs = (
         timestamp: new Date().toISOString(),
         log_override: true,
         projectId: config.projectId,
-        service: config.service
+        service: config.service,
+        LOG_TYPE: logType === 'aws' ? 'aws' : 'gcp'
     };
 
     return formatJsonLog(logData);

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -105,9 +105,9 @@ export const formatJsonLog = (
     const logType = (log.LOG_TYPE || log.logType || configLogType) as 'gcp' | 'aws';
     if (logType === "aws") {
         const awsLog: Record<string, any> = {
+            ...log,
             severity: SEVERITY_LEVEL[log.level || "info"] || log.severity || "INFO",
             timestamp: log.timestamp || log.time || new Date().toISOString(),
-            service: log.service || "api",
         };
     
         if (includeTrace && log.traceId) {
@@ -130,48 +130,64 @@ export const formatJsonLog = (
     
             const fullTraceId = `1-${epochHex}-${traceId24}`;
     
-            awsLog.trace = {
-                trace_id: fullTraceId,
-                segment_id: spanId16 || "0000000000000000",
-                sampled: true,
-            };
-    
+            awsLog.trace_id = fullTraceId;
+            awsLog.segment_id = spanId16 || "0000000000000000";
+            awsLog.sampled = true;
             awsLog["x-amzn-trace-id"] =
                 `Root=${fullTraceId};Parent=${spanId16};Sampled=1`;
         }
     
         const httpReq = log.httpRequest;
-        const method = log.method || httpReq?.requestMethod;
-        const url = log.url || log.path || httpReq?.requestUrl;
-        const clientIp = log.remoteAddress || httpReq?.remoteIp;
-        const contentLength = log.headers?.["content-length"] || httpReq?.requestSize;
-        const userAgent = log.headers?.["user-agent"] || httpReq?.userAgent;
-    
-        awsLog.request = {};
-        if (method) awsLog.request.method = method;
-        if (url) awsLog.request.url = url;
-        if (clientIp) awsLog.request.clientIp = clientIp;
-        if (contentLength)
-            awsLog.request.contentLength = Number(contentLength) || contentLength;
-        if (userAgent) awsLog.request.userAgent = userAgent;
-    
-        if (log.request_payload) {
-            awsLog.body = log.request_payload;
-        } else if (httpReq?.requestBody) {
-            awsLog.body = httpReq.requestBody;
+        if (httpReq) {
+            if (httpReq.graphql && !awsLog.graphql) {
+                awsLog.graphql = httpReq.graphql;
+            }
+            
+            if (!awsLog.method && httpReq.requestMethod) {
+                awsLog.method = httpReq.requestMethod;
+            }
+            if (!awsLog.url && httpReq.requestUrl) {
+                awsLog.url = httpReq.requestUrl;
+            }
+            if (!awsLog.path) {
+                if (log.path) {
+                    awsLog.path = log.path;
+                } else if (log.url) {
+                    awsLog.path = log.url;
+                } else if (httpReq.requestUrl) {
+                    try {
+                        const urlObj = new URL(httpReq.requestUrl);
+                        awsLog.path = urlObj.pathname;
+                    } catch {
+                        awsLog.path = httpReq.requestUrl;
+                    }
+                }
+            }
+            if (!awsLog.remoteAddress && httpReq.remoteIp) {
+                awsLog.remoteAddress = httpReq.remoteIp;
+            }
+            if (!awsLog.headers && httpReq.headers) {
+                awsLog.headers = httpReq.headers;
+            }
+            if (!awsLog.request_payload && httpReq.requestBody) {
+                awsLog.request_payload = httpReq.requestBody;
+            }
         }
     
         awsLog.aws = {
             cloudwatch: {
-                log_group: `/aws/service/${awsLog.service}`,
+                log_group: `/aws/service/${log.service || "api"}`,
                 log_stream: log.instance || "instance-1",
+                region: log.region || process.env.AWS_REGION || "ap-south-1",
+                account_id: log.account_id || process.env.AWS_ACCOUNT_ID || "123456789012",
             },
         };
+    
         const removeKeys = [
-            "pid", "hostname", "time", "msg", "level", "levelNumber",
-            "PROJECT_ID", "LOG_TYPE", "logType", "request_payload",
-            "method", "url", "path", "headers", "remoteAddress",
-            "type", "target_service", "httpRequest", "traceId", "spanId",
+            "pid", "hostname", "time", "levelNumber",
+            "PROJECT_ID", "LOG_TYPE", "logType",
+            "target_service", "traceId", "spanId",
+            "msg", "httpRequest",
             "logging.googleapis.com/trace",
             "logging.googleapis.com/spanId",
             "logging.googleapis.com/logName",

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -129,9 +129,9 @@ export const formatJsonLog = (
                 .toLowerCase();
     
             const fullTraceId = `1-${epochHex}-${traceId24}`;
-    
-            awsLog.trace_id = fullTraceId;
-            awsLog.segment_id = spanId16 || "0000000000000000";
+            
+            awsLog.traceId = fullTraceId;
+            awsLog.spanId = spanId16 || "0000000000000000";
             awsLog.sampled = true;
             awsLog["x-amzn-trace-id"] =
                 `Root=${fullTraceId};Parent=${spanId16};Sampled=1`;


### PR DESCRIPTION
## Summary
- add LOG_TYPE configuration support to switch between GCP and AWS logging behavior
- parse and emit AWS X-Amzn-Trace-Id headers while propagating the selected log type through request contexts
- format AWS logs without Google-specific fields and extend console overrides to honor the configured log type

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930733982988324bb82c27aac370a39)